### PR TITLE
Update TessC.swift

### DIFF
--- a/LibTessSwift/Classes/TessC.swift
+++ b/LibTessSwift/Classes/TessC.swift
@@ -45,7 +45,7 @@ public enum ContourOrientation {
 }
 
 /// Wraps the low-level C libtess2 library in a nice interface for Swift
-public class TessC {
+open class TessC {
     
     var memoryPool: MemPool?
     var mem: UnsafeMutablePointer<UInt8>?


### PR DESCRIPTION
exchanged Swift2's public definition by Swift3's open to make Tess3 subclassable outside of the very same module